### PR TITLE
Elaborating the 'dateofapplication' field for date-time format

### DIFF
--- a/applicant/applicants-swagger-api.yml
+++ b/applicant/applicants-swagger-api.yml
@@ -175,6 +175,7 @@ definitions:
         type: "string"
       dateofapplication:
         type: "string"
+        format: "date-time"
   newApplicant:
     type: "object"
     required:
@@ -221,6 +222,7 @@ definitions:
         type: "string"
       dateofapplication:
         type: "string"
+        format: "date-time"
   errorModel:
     type: "object"
     required:


### PR DESCRIPTION
Leaving 'dateofapplication' as a simple string field is likely to create a host of issues, allowing any date format to be entered.
We can fix this by further specifying the field to follow 'date' or 'date-time' format, as noted in the OpenAPI specification and defined by [RFC3339](https://xml2rfc.tools.ietf.org/public/rfc/html/rfc3339.html).